### PR TITLE
feat: Add 'Heatpump' service to SidebarItems

### DIFF
--- a/Code/bad_walden_stadtwerke/src/main/java/com/bad_walden_stadtwerke/components/mainApplication/SidebarItems.java
+++ b/Code/bad_walden_stadtwerke/src/main/java/com/bad_walden_stadtwerke/components/mainApplication/SidebarItems.java
@@ -1,7 +1,7 @@
 package com.bad_walden_stadtwerke.components.mainApplication;
 
-import com.bad_walden_stadtwerke.model.types.language.LanguageChangeObserver;
 import com.bad_walden_stadtwerke.controller.language.LanguageController;
+import com.bad_walden_stadtwerke.model.types.language.LanguageChangeObserver;
 import javafx.beans.value.ChangeListener;
 import javafx.scene.control.TreeItem;
 import javafx.scene.control.TreeView;
@@ -44,7 +44,7 @@ public class SidebarItems extends KeyedTreeItem implements LanguageChangeObserve
 	}
 
 	private KeyedTreeItem createCityServicesItem() {
-		return createTreeItem("sidebarCityServices", createServiceItems("sidebarWater", "sidebarElectricity", "sidebarGas", "sidebarBills"));
+		return createTreeItem("sidebarCityServices", createServiceItems("sidebarWater", "sidebarElectricity", "sidebarHeatpump", "sidebarGas", "sidebarBills"));
 	}
 
 	private KeyedTreeItem createAdminItem() {
@@ -56,7 +56,7 @@ public class SidebarItems extends KeyedTreeItem implements LanguageChangeObserve
 	}
 
 	private KeyedTreeItem createContractsItem() {
-		return createTreeItem("sidebarTariff", createServiceItems("sidebarWater", "sidebarElectricity", "sidebarGas"));
+		return createTreeItem("sidebarTariff", createServiceItems("sidebarWater", "sidebarElectricity", "sidebarHeatpump", "sidebarGas"));
 	}
 
 	private KeyedTreeItem createTreeItem(String key, List<KeyedTreeItem> children) {

--- a/Code/bad_walden_stadtwerke/src/main/resources/Bundle_de.properties
+++ b/Code/bad_walden_stadtwerke/src/main/resources/Bundle_de.properties
@@ -11,6 +11,7 @@ sidebarCityServices=Stadtwerke
 sidebarCustomers=Kunden
 sidebarElectricity=Strom
 sidebarGas=Gas
+sidebarHeatpump=Wärmepumpe
 sidebarHome=Start
 sidebarTariff=Tarif
 sidebarWater=Wasser

--- a/Code/bad_walden_stadtwerke/src/main/resources/Bundle_en.properties
+++ b/Code/bad_walden_stadtwerke/src/main/resources/Bundle_en.properties
@@ -11,6 +11,7 @@ sidebarCityServices=City Services
 sidebarCustomers=Customers
 sidebarElectricity=Electricity
 sidebarGas=Gas
+sidebarHeatpump=Heatpump
 sidebarHome=Home
 sidebarTariff=Tariff
 sidebarWater=Water


### PR DESCRIPTION
Add 'Heatpump' service item to SidebarItems for both English and German properties files. Expanded the list of services in the createContractsItem and createCityServicesItem methods in the SidebarItems class to include the new 'Heatpump' service.

solves #80 (zuhase -> start already done in previous pr)