### PR TITLE
feat: Add border styling to signup dialog views

### DIFF
--- a/Code/bad_walden_stadtwerke/src/main/java/com/bad_walden_stadtwerke/model/initialSignUp/SignUpManager.java
+++ b/Code/bad_walden_stadtwerke/src/main/java/com/bad_walden_stadtwerke/model/initialSignUp/SignUpManager.java
@@ -53,7 +53,6 @@ public class SignUpManager implements LanguageChangeObserver {
 		if (dialogRoot != null) {
 			Scene dialogScene = new Scene(dialogRoot, SCENE_WIDTH, SCENE_HEIGHT);
 			dialogStage.setScene(dialogScene);
-			dialogStage.getScene().getRoot().setStyle("-fx-border-color: black; -fx-border-width: 1px;");
 			dialogStage.showAndWait();
 			dialogStage.requestFocus();
 		}

--- a/Code/bad_walden_stadtwerke/src/main/resources/com/bad_walden_stadtwerke/view/initialSignUp/signup-dialog-0.fxml
+++ b/Code/bad_walden_stadtwerke/src/main/resources/com/bad_walden_stadtwerke/view/initialSignUp/signup-dialog-0.fxml
@@ -7,7 +7,7 @@
 <?import javafx.scene.layout.*?>
 <VBox xmlns:fx="http://javafx.com/fxml"
       fx:controller="com.bad_walden_stadtwerke.controller.initialSignUp.InitialSignUpControllerStep0"
-      prefWidth="1000" prefHeight="550" style="-fx-background-color: #f0f0f0;">
+      prefWidth="1000" prefHeight="550" style="-fx-background-color: #f0f0f0;-fx-border-color: #000000; -fx-border-width: 1px;">
     <HBox>
         <padding>
             <Insets bottom="20.0" left="20.0" right="20.0" top="20.0"/>

--- a/Code/bad_walden_stadtwerke/src/main/resources/com/bad_walden_stadtwerke/view/initialSignUp/signup-dialog-1.fxml
+++ b/Code/bad_walden_stadtwerke/src/main/resources/com/bad_walden_stadtwerke/view/initialSignUp/signup-dialog-1.fxml
@@ -5,7 +5,7 @@
 <?import javafx.scene.layout.*?>
 <VBox xmlns:fx="http://javafx.com/fxml"
       fx:controller="com.bad_walden_stadtwerke.controller.initialSignUp.InitialSignUpControllerStep1"
-      prefWidth="1000" prefHeight="550" style="-fx-background-color: #f0f0f0;">
+      prefWidth="1000" prefHeight="550" style="-fx-background-color: #f0f0f0;-fx-border-color: #000000; -fx-border-width: 1px;">
     <padding>
         <Insets bottom="20.0" left="20.0" right="20.0" top="20.0"/>
     </padding>

--- a/Code/bad_walden_stadtwerke/src/main/resources/com/bad_walden_stadtwerke/view/initialSignUp/signup-dialog-2.fxml
+++ b/Code/bad_walden_stadtwerke/src/main/resources/com/bad_walden_stadtwerke/view/initialSignUp/signup-dialog-2.fxml
@@ -5,7 +5,7 @@
 <?import javafx.scene.layout.*?>
 <VBox xmlns:fx="http://javafx.com/fxml"
       fx:controller="com.bad_walden_stadtwerke.controller.initialSignUp.InitialSignUpControllerStep2"
-      prefWidth="1000" prefHeight="550" style="-fx-background-color: #f0f0f0;">
+      prefWidth="1000" prefHeight="550" style="-fx-background-color: #f0f0f0;-fx-border-color: #000000; -fx-border-width: 1px;">
     <padding>
         <Insets bottom="20.0" left="20.0" right="20.0" top="20.0"/>
     </padding>

--- a/Code/bad_walden_stadtwerke/src/main/resources/com/bad_walden_stadtwerke/view/initialSignUp/signup-dialog-3.fxml
+++ b/Code/bad_walden_stadtwerke/src/main/resources/com/bad_walden_stadtwerke/view/initialSignUp/signup-dialog-3.fxml
@@ -5,7 +5,7 @@
 <?import javafx.scene.layout.*?>
 <VBox xmlns:fx="http://javafx.com/fxml"
       fx:controller="com.bad_walden_stadtwerke.controller.initialSignUp.InitialSignUpControllerStep3"
-      prefWidth="1000" prefHeight="550" style="-fx-background-color: #f0f0f0;">
+      prefWidth="1000" prefHeight="550" style="-fx-background-color: #f0f0f0;-fx-border-color: #000000; -fx-border-width: 1px;">
     <padding>
         <Insets bottom="20.0" left="20.0" right="20.0" top="20.0"/>
     </padding>

--- a/Code/bad_walden_stadtwerke/src/main/resources/com/bad_walden_stadtwerke/view/initialSignUp/signup-dialog-4.fxml
+++ b/Code/bad_walden_stadtwerke/src/main/resources/com/bad_walden_stadtwerke/view/initialSignUp/signup-dialog-4.fxml
@@ -6,7 +6,7 @@
 <?import javafx.scene.layout.VBox?>
 <VBox xmlns:fx="http://javafx.com/fxml"
       fx:controller="com.bad_walden_stadtwerke.controller.initialSignUp.InitialSignUpControllerStep4"
-      prefWidth="1000" prefHeight="550" style="-fx-background-color: #f0f0f0;">
+      prefWidth="1000" prefHeight="550" style="-fx-background-color: #f0f0f0;-fx-border-color: #000000; -fx-border-width: 1px;">
     <padding>
         <Insets bottom="20.0" left="20.0" right="20.0" top="20.0"/>
     </padding>


### PR DESCRIPTION
Add a black border with 1px width to all signup dialog views to enhance
visual presentation and improve user experience. Update styles in
signup-dialog-X.fxml files and remove redundant border styling from
SignUpManager class.