### PR TITLE
refactor: Check for null stage before instantiating FXMLUtility

### DIFF
--- a/Code/bad_walden_stadtwerke/src/main/java/com/bad_walden_stadtwerke/controller/initialSignUp/InitialSignUpControllerStep2.java
+++ b/Code/bad_walden_stadtwerke/src/main/java/com/bad_walden_stadtwerke/controller/initialSignUp/InitialSignUpControllerStep2.java
@@ -51,7 +51,12 @@ public class InitialSignUpControllerStep2 {
 		if (electricity == null) {
 			ExceptionPopup.showRefreshPopup(bundle.getString("signUpErrorTitle"), bundle.getString("signUpErrorText"));
 			Platform.runLater(() -> {
-				FXMLUtility fxmlUtility = new FXMLUtility(CURRENT_FXML_PATH, BUNDLE_NAME, (Stage) checkboxElectricity.getScene().getWindow());
+				Stage stage = (Stage) checkboxElectricity.getScene().getWindow();
+				if (stage == null) {
+					CentralLoggingUtility.handleEvent("Controller", "Stage is null");
+					return;
+				}
+				FXMLUtility fxmlUtility = new FXMLUtility(CURRENT_FXML_PATH, BUNDLE_NAME, stage);
 				fxmlUtility.loadAndSetScene();
 			});
 		}

--- a/Code/bad_walden_stadtwerke/src/main/java/com/bad_walden_stadtwerke/controller/initialSignUp/InitialSignUpControllerStep3.java
+++ b/Code/bad_walden_stadtwerke/src/main/java/com/bad_walden_stadtwerke/controller/initialSignUp/InitialSignUpControllerStep3.java
@@ -54,7 +54,11 @@ public class InitialSignUpControllerStep3 {
 		if (gas == null || heating == null) {
 			ExceptionPopup.showRefreshPopup(bundle.getString("signUpErrorTitle"), bundle.getString("signUpErrorText"));
 			Platform.runLater(() -> {
-				FXMLUtility fxmlUtility = new FXMLUtility(CURRENT_FXML_PATH, BUNDLE_NAME, (Stage) tabPane.getScene().getWindow());
+				Stage stage = (Stage) tabPane.getScene().getWindow();
+				if (stage == null) {
+					return;
+				}
+				FXMLUtility fxmlUtility = new FXMLUtility(CURRENT_FXML_PATH, BUNDLE_NAME,stage);
 				fxmlUtility.loadAndSetScene();
 			});
 		}


### PR DESCRIPTION
Added null check for stage before instantiating FXMLUtility in InitialSignUpControllerStep2 and InitialSignUpControllerStep3 to prevent NullPointerException.